### PR TITLE
Fix description of behavior of `hyde create -f`

### DIFF
--- a/content/commands.html
+++ b/content/commands.html
@@ -41,8 +41,8 @@ hyde [-s </site/path>] [-v] create [-l <layout>] [-f] [-h]
 :   Specifying this option will overwrite files and folders at the given
     site path.
 
-    *Optional* - If the target directory is not empty, hyde will throw an
-    exception unless this is specified.
+    *Optional* - If the target directory contains another Hyde site, hyde will
+    throw an exception unless this is specified.
 
 `-l LAYOUT, --layout LAYOUT`
 :   The name of the layout to use for creating the initial site. Hyde currently


### PR DESCRIPTION
The docs say that using -f will throw an exception if the target directory is
nonempty, however the actual behavior is to throw an exception if marker files
(either content/, layout/, or site.yaml) are present.
